### PR TITLE
スレッド一覧を表示するページ実装

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -48,9 +48,9 @@ export default createRoute(async (c) => {
   return c.render(
     <main className="container mx-auto flex-grow py-8 px-4">
       <section className="bg-white rounded-lg shadow-md p-6 mb-8">
-        <ul className="flex flex-col gap-2">
+        <ul className="flex flex-wrap gap-4">
           {threadTop30.map((thread, index) => (
-            <li key={thread.id.val} className="">
+            <li key={thread.id.val} className="flex-none">
               <a
                 className="text-purple-600 underline"
                 href={`/threads/${thread.id.val}`}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -48,6 +48,9 @@ export default createRoute(async (c) => {
   return c.render(
     <main className="container mx-auto flex-grow py-8 px-4">
       <section className="bg-white rounded-lg shadow-md p-6 mb-8">
+        <div className="mb-4">
+          <h2 className="text-xl font-semibold">人気スレッド</h2>
+        </div>
         <ul className="flex flex-wrap gap-4">
           {threadTop30.map((thread, index) => (
             <li key={thread.id.val} className="flex-none">
@@ -60,6 +63,11 @@ export default createRoute(async (c) => {
             </li>
           ))}
         </ul>
+        <div className="mt-4">
+          <a href="/subback.html" className="text-blue-600 hover:underline">
+            全スレッド一覧
+          </a>
+        </div>
       </section>
 
       <section className="mb-8">

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -53,7 +53,7 @@ export default createRoute(async (c) => {
             <li key={thread.id.val} className="flex-none">
               <a
                 className="text-purple-600 underline"
-                href={`/threads/${thread.id.val}`}
+                href={`/threads/${thread.id.val}/l50`}
               >
                 {index + 1}: {thread.title.val} ({thread.countResponse})
               </a>

--- a/app/routes/subback.html.tsx
+++ b/app/routes/subback.html.tsx
@@ -1,0 +1,71 @@
+import { createRoute } from "honox/factory";
+
+import { getAllThreadsPageUsecase } from "../../src/conversation/usecases/getAllThreadsPageUsecase";
+import { ErrorMessage } from "../components/ErrorMessage";
+
+export default createRoute(async (c) => {
+  const { sql, logger } = c.var;
+
+  logger.info({
+    operation: "subback/GET",
+    path: c.req.path,
+    method: c.req.method,
+    message: "Rendering thread list page",
+  });
+
+  logger.debug({
+    operation: "subback/GET",
+    message: "Calling getAllThreadsPageUsecase to retrieve all threads",
+  });
+
+  const usecaseResult = await getAllThreadsPageUsecase({
+    sql,
+    logger,
+  });
+
+  if (usecaseResult.isErr()) {
+    logger.error({
+      operation: "subback/GET",
+      error: usecaseResult.error,
+      message: "Failed to retrieve all threads",
+    });
+    return c.render(<ErrorMessage error={usecaseResult.error} />);
+  }
+
+  const threads = usecaseResult.value;
+
+  logger.debug({
+    operation: "subback/GET",
+    threadCount: threads.length,
+    message: "Successfully retrieved all threads, rendering page",
+  });
+
+  return c.render(
+    <main className="container mx-auto flex-grow py-8 px-4">
+      <section className="bg-white rounded-lg shadow-md p-6 mb-8">
+        <h1 className="text-2xl font-bold mb-4">スレッド一覧</h1>
+
+        <p className="mb-4">全部で{threads.length}のスレッドがあります</p>
+
+        <ul className="flex flex-col gap-2">
+          {threads.map((thread, index) => (
+            <li key={thread.id.val}>
+              <a
+                className="text-purple-600 hover:underline"
+                href={`/threads/${thread.id.val}/l50`}
+              >
+                {index + 1}: {thread.title.val} ({thread.countResponse})
+              </a>
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-6">
+          <a href="/" className="text-blue-600 hover:underline">
+            掲示板に戻る
+          </a>
+        </div>
+      </section>
+    </main>
+  );
+});


### PR DESCRIPTION
# 概要

スレッド一覧を取得するページが存在しなかったので実装した

# 詳細

- [x] スレッド一覧を取得するページを実装
- [x] スレッド一覧を取得するページへのリンクを追加
- [x] 人気のスレッドを表示する部分のスタイルを変更(横並びにした)  

![image](https://github.com/user-attachments/assets/86780c19-1177-44b3-9f25-453745ebf73a)
