### PR TITLE
cloudflare workersデプロイなどでタイムゾーンがずれる問題を修正

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -101,7 +101,10 @@ export default createRoute(async (c) => {
                         名前: {formatReadAuthorName(resp.authorName)}
                       </span>
                       <span className="text-gray-500 text-sm">
-                        {formatDate(resp.postedAt.val)}
+                        {formatDate(resp.postedAt.val, {
+                          acceptLanguage:
+                            c.req.header("Accept-Language") ?? undefined,
+                        })}
                       </span>
                       <span className="text-gray-500 text-sm">
                         ID: {resp.hashId.val}

--- a/app/routes/senbura/dat/[iddat].tsx
+++ b/app/routes/senbura/dat/[iddat].tsx
@@ -33,7 +33,9 @@ export default createRoute(async (c) => {
   const title = responsesResult.value.thread.threadTitle.val;
   let text = "";
   for (const resp of responsesResult.value.responses) {
-    const formattedDate = formatDate(resp.postedAt.val);
+    const formattedDate = formatDate(resp.postedAt.val, {
+      acceptLanguage: c.req.header("Accept-Language") ?? undefined,
+    });
     const formattedUserName = formatReadAuthorName(resp.authorName);
 
     text += `${formattedUserName}<>${resp.mail.val}<>${formattedDate} ID:${

--- a/app/routes/threads/[id]/[query].tsx
+++ b/app/routes/threads/[id]/[query].tsx
@@ -170,7 +170,10 @@ export default createRoute(async (c) => {
                     {formatReadAuthorName(resp.authorName)}
                   </span>
                   <span className="text-gray-500 text-sm">
-                    {formatDate(resp.postedAt.val)}
+                    {formatDate(resp.postedAt.val, {
+                      acceptLanguage:
+                        c.req.header("Accept-Language") ?? undefined,
+                    })}
                   </span>
                   <span className="text-gray-500 text-sm">
                     ID: {resp.hashId.val}

--- a/app/routes/threads/[id]/index.tsx
+++ b/app/routes/threads/[id]/index.tsx
@@ -92,7 +92,10 @@ export default createRoute(async (c) => {
                     {formatReadAuthorName(resp.authorName)}
                   </span>
                   <span className="text-gray-500 text-sm">
-                    {formatDate(resp.postedAt.val)}
+                    {formatDate(resp.postedAt.val, {
+                      acceptLanguage:
+                        c.req.header("Accept-Language") ?? undefined,
+                    })}
                   </span>
                   <span className="text-gray-500 text-sm">
                     ID: {resp.hashId.val}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "private": true,
   "dependencies": {
     "bcrypt-ts": "^6.0.0",
+    "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "encoding-japanese": "^2.2.0",
     "hono": "^4.7.4",
     "hono-pino": "^0.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       bcrypt-ts:
         specifier: ^6.0.0
         version: 6.0.0
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
+      date-fns-tz:
+        specifier: ^3.2.0
+        version: 3.2.0(date-fns@4.1.0)
       encoding-japanese:
         specifier: ^2.2.0
         version: 2.2.0
@@ -1440,6 +1446,14 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns-tz@3.2.0:
+    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
+    peerDependencies:
+      date-fns: ^3.0.0 || ^4.0.0
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   dbmate@2.26.0:
     resolution: {integrity: sha512-PZwU/dDm3s3bMN0Ra1SSF3i0sKUy9Ms9QnokrUZHYoKvaJyLFw2XnlTl21ivLJLbOZ/rUPzbpPddGJMzmPNt1Q==}
@@ -4335,6 +4349,12 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns-tz@3.2.0(date-fns@4.1.0):
+    dependencies:
+      date-fns: 4.1.0
+
+  date-fns@4.1.0: {}
 
   dbmate@2.26.0:
     optionalDependencies:

--- a/src/shared/utils/formatDate.ts
+++ b/src/shared/utils/formatDate.ts
@@ -3,44 +3,27 @@ import { formatInTimeZone } from "date-fns-tz";
 
 import type { Locale } from "date-fns";
 
-// Accept-Language ヘッダから簡易的にタイムゾーンを推定
-/**
- * Accept-Language ヘッダから言語を判定し、標準的な IANA タイムゾーンを推定
- */
+// モジュールロード時に実行環境のタイムゾーンをキャッシュ
+const defaultTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+// Accept-Language ヘッダから言語を判定し、標準的な IANA タイムゾーンを推定
 function inferTimeZone(code: string): string {
   if (code.startsWith("ja")) return "Asia/Tokyo";
   if (code.startsWith("en-us")) return "America/New_York";
   if (code.startsWith("en-gb")) return "Europe/London";
-  // その他は実行環境のタイムゾーン
-  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return defaultTimeZone;
 }
 
-// Accept-Language ヘッダとタイムゾーン対応した日付フォーマット
 /**
- * Accept-Language ヘッダから言語を判定し、標準的な IANA タイムゾーンを推定してフォーマット
+ * Accept-Language ヘッダを参照し、対応するロケール／タイムゾーンで日付をフォーマット
  */
 export function formatDate(
   date: Date,
   options?: { acceptLanguage?: string }
 ): string {
-  // 曜日マップ
-  const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
-  // ロケール選択
   const lang = options?.acceptLanguage?.split(",")[0].toLowerCase() || "";
-  const locale: Locale = lang.startsWith("ja") ? ja : enUS;
-  // タイムゾーン推定
-
   const tz = inferTimeZone(lang);
-  // yyyy/MM/dd HH:mm:ss.SS までフォーマット
-  const formatted = formatInTimeZone(date, tz, "yyyy/MM/dd HH:mm:ss.SS", {
-    locale,
-  });
-  // フォーマット結果に曜日挿入: formatted例 "2025/02/23 08:41:28.90"
-  const [ymd, hmss] = formatted.split(" ");
-  // タイムゾーン考慮後の週日取得
-  const zonedDate = new Date(
-    formatInTimeZone(date, tz, "yyyy-MM-dd'T'HH:mm:ssXXX")
-  );
-  const dow = weekdays[zonedDate.getDay()];
-  return `${ymd}(${dow}) ${hmss} (${tz})`;
+  const locale: Locale = lang.startsWith("ja") ? ja : enUS;
+  // 一度の呼び出しで yyyy/MM/dd(E) HH:mm:ss.SS (タイムゾーン) を埋め込む
+  const pattern = `yyyy/MM/dd(E) HH:mm:ss.SS '(${tz})'`;
+  return formatInTimeZone(date, tz, pattern, { locale });
 }


### PR DESCRIPTION
# 概要

cloudflare workersなどでデプロイ先のタイムゾーンに日付の表示が依存する問題に
対処できるようにしてみた。

# 詳細

- [x] `Accept-Language` ヘッダでタイムゾーンを簡易的に判定するようformatDate関数を改良
- [x] ヘッダの取得と引数への渡し追加