### PR TITLE
sageの扱いの条件が逆になっていたので修正

### DIFF
--- a/src/conversation/usecases/postResponseByThreadEpochIdUsecase.ts
+++ b/src/conversation/usecases/postResponseByThreadEpochIdUsecase.ts
@@ -256,7 +256,7 @@ export const postResponseByThreadEpochIdUsecase = async (
 
   // また、スレッドのupdated_atも更新する必要がある
   // メールが'sage'でない場合のみ
-  if (isSage(mailResult.value)) {
+  if (!isSage(mailResult.value)) {
     logger.debug({
       operation: "postResponseByThreadEpochId",
       threadId: writeThreadIdResult.value.val,


### PR DESCRIPTION
## 概要

専用ブラウザから投稿すると

- デフォルトで`sage`状態
- `sage`にしたときだけ非`sage`状態

になっていたので修正した

## 詳細

- [x] sage判定の条件に!を追加